### PR TITLE
One more change for zsh and the latest terraform release

### DIFF
--- a/source.sh
+++ b/source.sh
@@ -12,5 +12,5 @@ if [ ! -d ~/.tvm/bin ] || [ ! -f ~/.tvm/bin/tvm ] || [ "$(cd "$(dirname "${BASH_
     mkdir -p ~/.tvm/bin
     ln -sf "$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)/tvm" ~/.tvm/bin/tvm
 fi
-export PATH="$PATH:~/.tvm/bin"
+export PATH="$PATH:$HOME/.tvm/bin"
 

--- a/tvm
+++ b/tvm
@@ -15,7 +15,11 @@ version=$1
 exe_file=~/.tvm/versions/$version
 
 if [ ! -f $exe_file ]; then
-    curl https://releases.hashicorp.com/terraform/$version/terraform_${version}_${ARCH}.zip | funzip > $exe_file
+    tempfile=$(mktemp)
+    trap 'rm -f "$tempfile"' EXIT
+
+    curl https://releases.hashicorp.com/terraform/$version/terraform_${version}_${ARCH}.zip --output $tempfile
+    unzip -p $tempfile terraform > $exe_file
     chmod +x $exe_file
 fi
 


### PR DESCRIPTION
- zsh doesn't seem to want to expand ~ in PATH
- The latest Terraform release ships with a LICENSE.txt file, which breaks funzip streaming unzip